### PR TITLE
Travis testing, Python compatibility Trove & Python 3.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: python
+matrix:
+    include:
+      - python: 2.7
+        env: TOXENV=py27
+      - python: 3.3
+        env: TOXENV=py33
+      - python: 3.4
+        env: TOXENV=py34
+      - python: 3.5 # not yet pre-installed in Travis base image
+        env: TOXENV=py35
+install:
+  - pip install tox
+script:
+  - tox -e $TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
         env: TOXENV=py34
       - python: 3.5 # not yet pre-installed in Travis base image
         env: TOXENV=py35
+      - python: 3.6 # not yet pre-installed in Travis base image
+        env: TOXENV=py36
 install:
   - pip install tox
 script:

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,5 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5"])
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6"])

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,8 @@ setup(
     entry_points={'pytest11': ['pytest_warnings = pytest_warnings']},
     install_requires=['pytest'],
     classifiers=[
-        "Framework :: Pytest"])
+        "Framework :: Pytest",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5"])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
* Enables Travis testing across all supported Python versions using existing tox setup
* Adds Python supported versions to the Trove listing
* Adds testing against Python 3.6