### PR TITLE
Update development status classifier to inactive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 pytest-warnings
 ===============
 
+Warning
+
+This package is inactive and will not be maintained. The functionality of this package is
+present in `pytest <https://pypi.org/project/pytest/>`_.
+
 py.test plugin to list Python warnings in pytest report.
 
 Integrated in pytest >= 3.1.0.

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6"])
+        "Programming Language :: Python :: 3.6",
+        "Development Status :: 7 - Inactive",
+        ],
+)


### PR DESCRIPTION
Since this project has been abandoned due to the functionality being included with pytest itself, the classifier could be updated to reflect that. Maybe the leftover open issues could be closed as well, especially since they seem to be solved.

If you could rerelease the package with the updated classifiers, that would be awesome! The final patch ;)